### PR TITLE
添加智谱视觉模型的支持

### DIFF
--- a/api_loader.py
+++ b/api_loader.py
@@ -11,6 +11,19 @@ config_manager = ConfigManager()
 # Expanded model configurations
 # 每个 provider 包含 base_url、t2t_models（文本模型）、ti2t_models（视觉模型）
 MODEL_CONFIGS = {
+    "智谱AI": {
+        "base_url": "https://open.bigmodel.cn/api/paas/v4/",
+        "t2t_models": [
+            "glm-4.5-Flash",
+            "glm-4-Flash-250414",
+            "glm-Z1-Flash"
+        ],
+        "ti2t_models": [
+            "glm-4.6V-Flash",
+            "glm-4V-Flash",
+            "glm-4.1V-Thinking-Flash"
+        ]
+    },
     "OpenAI": {
         "base_url": "https://api.openai.com/v1",
         "t2t_models": [
@@ -177,14 +190,14 @@ MODEL_CONFIGS = {
             "Qwen/QwQ-32B",
             "Pro/Qwen/Qwen2.5-7B-Instruct",
             "Pro/Qwen/Qwen2-7B-Instruct",
-            # GLM 系列（智谱）
-            "zai-org/GLM-4.6",
-            "zai-org/GLM-4.5-Air",
-            "zai-org/GLM-4.5",
-            "THUDM/GLM-Z1-32B-0414",
-            "THUDM/GLM-4-32B-0414",
-            "THUDM/GLM-Z1-Rumination-32B-0414",
-            "THUDM/GLM-4-9B-0414",
+            # glm 系列（智谱）
+            "zai-org/glm-4.6",
+            "zai-org/glm-4.5-Air",
+            "zai-org/glm-4.5",
+            "THUDM/glm-Z1-32B-0414",
+            "THUDM/glm-4-32B-0414",
+            "THUDM/glm-Z1-Rumination-32B-0414",
+            "THUDM/glm-4-9B-0414",
             "THUDM/glm-4-9b-chat",
             "Pro/THUDM/glm-4-9b-chat",
             # 其他模型
@@ -227,15 +240,17 @@ MODEL_CONFIGS = {
             "Qwen/Qwen3-Omni-30B-A3B-Captioner",
             # QVQ 系列
             "Qwen/QVQ-72B-Preview",
-            # GLM V 系列（视觉）
-            "zai-org/GLM-4.5V",
-            "Pro/THUDM/GLM-4.1V-9B-Thinking",
-            "THUDM/GLM-4.1V-9B-Thinking"
+            # glm V 系列（视觉）
+            "zai-org/glm-4.5V",
+            "Pro/THUDM/glm-4.1V-9B-Thinking",
+            "THUDM/glm-4.1V-9B-Thinking"
         ]
     },
     "Ollama (Local)": {
         "base_url": "http://127.0.0.1:11434/v1",
         "t2t_models": [
+            "huihui_ai/qwen3-vl-abliterated:8b-instruct",
+            "huihui_ai/qwen3-vl-abliterated:4b-instruct",
             "llama4",
             "llama3.3",
             "llama3.2",
@@ -246,8 +261,8 @@ MODEL_CONFIGS = {
             "phi4"
         ],
         "ti2t_models": [
-            "llama3.2-vision",
-            "llava"
+            "huihui_ai/qwen3-vl-abliterated:8b-instruct",
+            "huihui_ai/qwen3-vl-abliterated:4b-instruct"
         ]
     },
     "Custom": {

--- a/api_loader.py
+++ b/api_loader.py
@@ -91,7 +91,13 @@ MODEL_CONFIGS = {
             "gemini-1.5-flash",
             "gemini-1.5-flash-8b"
         ],
-        "ti2t_models": []
+        "ti2t_models": [
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+            "gemini-2.0-flash",
+            "gemini-2.0-flash-lite",
+            "gemini-2.0-flash-live"
+        ]
     },
     "Anthropic (Claude)": {
         "base_url": "https://api.anthropic.com/v1",
@@ -145,7 +151,12 @@ MODEL_CONFIGS = {
             "qwen-max",
             "qwen-turbo"
         ],
-        "ti2t_models": []
+        "ti2t_models": [
+            "qwen3-vl-flash",
+            "qwen3-vl-flash-2025-10-15",
+            "qwen3-vl-plus",
+            "qwen3-vl-plus-2025-09-23"
+        ]
     },
     "SiliconFlow (硅基流动)": {
         "base_url": "https://api.siliconflow.cn/v1",

--- a/search_agent.py
+++ b/search_agent.py
@@ -443,6 +443,11 @@ class LiveSearch_Agent:
     
     # 模式分组：TI2T 需要图片输入；Dual 表示模型原生支持多模态但可向下兼容文本
     TI2T_MODELS = {
+        "智谱AI": {
+            "glm-4.6V-Flash",
+            "glm-4V-Flash",
+            "glm-4.1V-Thinking-Flash"
+        },
         "OpenAI": {
             # OpenAI 视觉模型（使用 OpenAI 兼容格式，与 SiliconFlow 相同）
             "gpt-5.1",
@@ -485,6 +490,8 @@ class LiveSearch_Agent:
             "THUDM/GLM-4.1V-9B-Thinking"
         },
         "Ollama (Local)": {
+            "huihui_ai/qwen3-vl-abliterated:8b-instruct",
+            "huihui_ai/qwen3-vl-abliterated:4b-instruct",
             "llama3.2-vision",
             "llava"
         },
@@ -890,10 +897,7 @@ Rules:
 6. Do not answer the question yet."""
                 
                 query_gen_content = [
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{image_b64}", "detail": "auto"}
-                    },
+                    self._build_image_content(image_b64, provider, model),
                     {"type": "text", "text": f"User Question: {prompt}{location_hint}\nGenerate a search query:"}
                 ]
                 
@@ -996,10 +1000,7 @@ Rules:
                  final_system_prompt = f"{role}\n\nSystem Rules:\n1. {language_instruction}\n2. Use provided search results and image."
 
             final_user_content = [
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_b64}", "detail": "auto"}
-                },
+                self._build_image_content(image_b64, provider, model),
                 {"type": "text", "text": f"User Question: {prompt} {lang_suffix}\n\nSearch Results:\n{full_context}"}
             ]
             
@@ -1024,10 +1025,7 @@ Rules:
                 system_prompt = f"{role}\n\nSystem Rules:\n1. {language_instruction}"
 
             user_content = [
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_b64}", "detail": "auto"}
-                },
+                self._build_image_content(image_b64, provider, model),
                 {"type": "text", "text": prompt} if prompt.strip() else {"type": "text", "text": "Describe this image."}
             ]
             
@@ -1080,6 +1078,32 @@ Rules:
         except Exception as e:
             print(f"[LiveSearch] Failed to encode image for TI2T: {e}")
             return None
+    
+    @staticmethod
+    def _build_image_content(image_b64, provider, model):
+        """
+        Build image content for different providers
+        Returns the appropriate image_url format based on provider
+        """
+        base64_url = f"data:image/png;base64,{image_b64}"
+        
+        # Check if model supports base64 (GLM-4V-Flash does not support base64)
+        if "智谱AI" in provider or "Zhipu" in provider:
+            # GLM-4V-Flash does not support base64 encoding
+            if "glm-4v-flash" in model.lower():
+                print(f"[LiveSearch] Warning: {model} does not support base64 encoding. Image upload may fail.")
+            
+            # Zhipu AI format: no 'detail' parameter
+            return {
+                "type": "image_url",
+                "image_url": {"url": base64_url}
+            }
+        
+        # OpenAI format (includes 'detail' parameter)
+        return {
+            "type": "image_url",
+            "image_url": {"url": base64_url, "detail": "auto"}
+        }
     
     @classmethod
     def _is_ti2t_model(cls, provider, model):

--- a/search_agent.py
+++ b/search_agent.py
@@ -332,11 +332,10 @@ class LLMClient:
         elif "Aliyun" in provider or provider in ["DeepSeek (Aliyun)", "Qwen (Aliyun)"]:
             # DashScope compatible mode uses Bearer token (OpenAI format)
             headers["Authorization"] = f"Bearer {api_key}"
-        # Gemini (OpenAI-Format) - API key should be in query parameter, not header
+        # Gemini (OpenAI-Format) - uses standard Authorization header
         elif "Gemini" in provider:
-            # Gemini's OpenAI-compatible endpoint uses ?key= query parameter
-            # Don't add Authorization header for Gemini
-            url = f"{url}?key={api_key}"
+            # Gemini's OpenAI-compatible endpoint uses standard Bearer token
+            headers["Authorization"] = f"Bearer {api_key}"
         # Ollama (Local) - usually no auth needed, but some setups use it
         elif "Ollama" in provider:
             # Ollama typically doesn't need auth, but if API key is provided, use it
@@ -459,6 +458,12 @@ class LiveSearch_Agent:
             "gpt-4o-mini",
             "gpt-4-turbo"
         },
+        "Qwen (Aliyun)": {
+            "qwen3-vl-flash",
+            "qwen3-vl-flash-2025-10-15",
+            "qwen3-vl-plus",
+            "qwen3-vl-plus-2025-09-23"
+        },
         "SiliconFlow (硅基流动)": {
             # DeepSeek VLM 系列
             "deepseek-ai/DeepSeek-OCR",
@@ -494,6 +499,13 @@ class LiveSearch_Agent:
             "huihui_ai/qwen3-vl-abliterated:4b-instruct",
             "llama3.2-vision",
             "llava"
+        },
+        "Gemini (OpenAI-Format)": {
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+            "gemini-2.0-flash",
+            "gemini-2.0-flash-lite",
+            "gemini-2.0-flash-live"
         },
         "Custom": {
             "custom-vlm-model"

--- a/web/live_search.js
+++ b/web/live_search.js
@@ -76,7 +76,13 @@ const API_LOADER_MODEL_CONFIGS = {
             "gemini-1.5-flash",
             "gemini-1.5-flash-8b"
         ],
-        "ti2t_models": []
+        "ti2t_models": [
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+            "gemini-2.0-flash",
+            "gemini-2.0-flash-lite",
+            "gemini-2.0-flash-live"
+        ]
     },
     "Anthropic (Claude)": {
         "t2t_models": [
@@ -123,7 +129,12 @@ const API_LOADER_MODEL_CONFIGS = {
             "qwen-max",
             "qwen-turbo"
         ],
-        "ti2t_models": []
+        "ti2t_models": [
+            "qwen3-vl-flash",
+            "qwen3-vl-flash-2025-10-15",
+            "qwen3-vl-plus",
+            "qwen3-vl-plus-2025-09-23"
+        ]
     },
     "SiliconFlow (硅基流动)": {
         "t2t_models": [

--- a/web/live_search.js
+++ b/web/live_search.js
@@ -2,6 +2,18 @@ import { app } from "../../scripts/app.js";
 
 // Model configurations for API Loader
 const API_LOADER_MODEL_CONFIGS = {
+    "智谱AI": {
+        "t2t_models": [
+            "glm-4.5-Flash",
+            "glm-4-Flash-250414",
+            "glm-Z1-Flash"
+        ],
+        "ti2t_models": [
+            "glm-4.6V-Flash",
+            "glm-4V-Flash",
+            "glm-4.1V-Thinking-Flash"
+        ]
+    },
     "OpenAI": {
         "t2t_models": [
             "gpt-5.1",
@@ -153,13 +165,13 @@ const API_LOADER_MODEL_CONFIGS = {
             "Qwen/QwQ-32B",
             "Pro/Qwen/Qwen2.5-7B-Instruct",
             "Pro/Qwen/Qwen2-7B-Instruct",
-            "zai-org/GLM-4.6",
-            "zai-org/GLM-4.5-Air",
-            "zai-org/GLM-4.5",
-            "THUDM/GLM-Z1-32B-0414",
-            "THUDM/GLM-4-32B-0414",
-            "THUDM/GLM-Z1-Rumination-32B-0414",
-            "THUDM/GLM-4-9B-0414",
+            "zai-org/glm-4.6",
+            "zai-org/glm-4.5-Air",
+            "zai-org/glm-4.5",
+            "THUDM/glm-Z1-32B-0414",
+            "THUDM/glm-4-32B-0414",
+            "THUDM/glm-Z1-Rumination-32B-0414",
+            "THUDM/glm-4-9B-0414",
             "THUDM/glm-4-9b-chat",
             "Pro/THUDM/glm-4-9b-chat",
             "inclusionAI/Ling-1T",
@@ -195,13 +207,15 @@ const API_LOADER_MODEL_CONFIGS = {
             "Qwen/Qwen3-Omni-30B-A3B-Thinking",
             "Qwen/Qwen3-Omni-30B-A3B-Captioner",
             "Qwen/QVQ-72B-Preview",
-            "zai-org/GLM-4.5V",
-            "Pro/THUDM/GLM-4.1V-9B-Thinking",
-            "THUDM/GLM-4.1V-9B-Thinking"
+            "zai-org/glm-4.5V",
+            "Pro/THUDM/glm-4.1V-9B-Thinking",
+            "THUDM/glm-4.1V-9B-Thinking"
         ]
     },
     "Ollama (Local)": {
         "t2t_models": [
+            "huihui_ai/qwen3-vl-abliterated:8b-instruct",
+            "huihui_ai/qwen3-vl-abliterated:4b-instruct",
             "llama4",
             "llama3.3",
             "llama3.2",
@@ -212,8 +226,8 @@ const API_LOADER_MODEL_CONFIGS = {
             "phi4"
         ],
         "ti2t_models": [
-            "llama3.2-vision",
-            "llava"
+            "huihui_ai/qwen3-vl-abliterated:8b-instruct",
+            "huihui_ai/qwen3-vl-abliterated:4b-instruct"
         ]
     },
     "Custom": {


### PR DESCRIPTION
修改了智谱模型视觉的调用接口，测试后功能正常，但是并没有详细测试不修改是否可以全部正常调用

原调用方式
{
  "type": "image_url",
  "image_url": {
    "url": "data:image/png;base64,...",
    "detail": "auto"  // ⚠️ 这是OpenAI特有的参数
  }
}

智谱官方
{
  "type": "image_url",
  "image_url": {
    "url": "data:image/png;base64,..."  // 没有 detail 字段
  }
}